### PR TITLE
More meaningful fixture naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Add a `_` prefix to the fixture used to define the database URL: from `database_url` to
+  `_database_url`
+- `_database_url` value is overridden by the `--database-url` CLI option, if given
+- `_engine` fixture renamed to `sqla_engine`
+- `database` fixture renamed to `scoped_database`. A new fixture named `database` gives
+  access to the test session database
+- `function_scoped_database` fixture renamed to `scoped_sqla_engine`
+- `db_session` fixture renamed to `dbsession` (`dbsession` fixture was kept for 
+  backward compatibility)
+
+### Fixed
+
+- Fixed issue to create the test database when default user not set to "postgres" (#2)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ the testing database: `database_url` and `init_database`. These two **must** be
 defined in your project `conftest.py` like below:
 
     @pytest.fixture(scope="session")
-    def database_url():
+    def _database_url():
         return "postgresql+asyncpg://postgres:masterkey@localhost/dbtest"
     
     
@@ -52,20 +52,21 @@ defined in your project `conftest.py` like below:
     
         return metadata.create_all
 
-The `database_url` must be a session-scoped fixture that returns the database URI.
-`init_database` must also be a session-scoped fixture that returns the callable used
-to initialize the database (in most cases, this would return the 
+The `_database_url` must be a session-scoped fixture that returns the database URL in
+SQLAlchemy standard. `init_database` must also be a session-scoped fixture that returns
+the callable used to initialize the database (in most cases, this would return the 
 `metadata.create_all` function).    
 
 ## Usage
 
 This plugin provides the following fixtures:
 
-- `dbsession`: An `AsyncSession` object bounded to the test database. Database changes
-  are discarded after each test function, so the same database is used for the entire 
-  test suite (avoiding the overhead of initializing a database on every test).
-- `database`: `database` provides a new database within the scope of the test function. 
-  The value of the fixture is a string URL pointing to the database.
+- `db_session`: An `AsyncSession` object bounded to the test session database. Database 
+  transactions are discarded after each test function, so the same database is used for 
+  the entire test suite (avoiding the overhead of initializing a database on every test).
+- `database`: An URL to the initialized test session database.
+- `scoped_database`: `scoped_database` provides a new database within the scope of the
+  test function. The value of the fixture is a string URL pointing to the database.
 
 ## Contributing
 

--- a/pytest_async_sqlalchemy.py
+++ b/pytest_async_sqlalchemy.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
-import asyncio
-import sys
-
 import pytest
 from sqlalchemy import text
-from sqlalchemy.engine import make_url, URL
-from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, AsyncEngine
+from sqlalchemy.engine import make_url
+from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker
 
 
@@ -19,93 +16,23 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture(scope="session")
-def _database_url(database_url, request) -> URL:
-    url = request.config.getoption("database_url") or database_url
-    return make_url(url)
-
-
-async def create_database(url: URL):
-    database_name = url.database
-    dbms_url = url.set(database="postgres")
-    engine = create_async_engine(dbms_url, isolation_level="AUTOCOMMIT")
-
-    async with engine.connect() as conn:
-        c = await conn.execute(
-            text(f"SELECT 1 FROM pg_database WHERE datname='{database_name}'")
-        )
-        database_exists = c.scalar() == 1
-
-    if database_exists:
-        await drop_database(url)
-
-    async with engine.connect() as conn:
-        await conn.execute(
-            text(f'CREATE DATABASE "{database_name}" ENCODING "utf8" TEMPLATE template1')
-        )
-
-
-async def drop_database(url: URL):
-    dbms_url = url.set(database="postgres")
-    engine = create_async_engine(dbms_url, isolation_level="AUTOCOMMIT")
-    async with engine.connect() as conn:
-        disc_users = """
-        SELECT pg_terminate_backend(pg_stat_activity.%(pid_column)s)
-        FROM pg_stat_activity
-        WHERE pg_stat_activity.datname = '%(database)s'
-          AND %(pid_column)s <> pg_backend_pid();
-        """ % {
-            "pid_column": "pid",
-            "database": url.database,
-        }
-        await conn.execute(text(disc_users))
-
-        await conn.execute(text(f'DROP DATABASE "{url.database}"'))
+def database_url(request):
+    effective_url = request.config.getoption("database_url")
+    if effective_url:
+        return effective_url
+    else:
+        try:
+            return request.getfixturevalue("_database_url")
+        except pytest.FixtureLookupError:
+            pytest.exit(
+                'Database URL not given. Define a "_database_url" session fixture or '
+                'use the "--database-url" in the command line.',
+                returncode=1,
+            )
 
 
 @pytest.fixture(scope="session")
-async def _engine(_database_url, event_loop, init_database):
-    await create_database(_database_url)
-
-    engine = create_async_engine(_database_url)
-    async with engine.begin() as conn:
-        await conn.run_sync(init_database)
-
-    try:
-        yield engine
-    finally:
-        await engine.dispose()
-        await drop_database(_database_url)
-
-
-@pytest.fixture(scope="function")
-async def function_scoped_database(_database_url, init_database) -> AsyncEngine:
-    """
-    This fixture creates a new database just for the test function being run (instead of
-    using the same database for the entire test session).
-    """
-    new_database_name = _database_url.database + "_function_scoped"
-    function_scoped_database_url = _database_url.set(database=new_database_name)
-    await create_database(function_scoped_database_url)
-
-    engine = create_async_engine(function_scoped_database_url)
-    async with engine.begin() as conn:
-        await conn.run_sync(init_database)
-
-    try:
-        yield engine
-    finally:
-        await engine.dispose()
-        await drop_database(function_scoped_database_url)
-
-
-@pytest.fixture(scope="function")
-async def database(_database_url, init_database) -> str:
-    """
-    This fixture creates a new database just for the test function being run.
-    """
-    database_url = _database_url.set(
-        database=_database_url.database + "_function_scoped"
-    )
+async def database(database_url, event_loop, init_database):
     await create_database(database_url)
 
     engine = create_async_engine(database_url)
@@ -119,13 +46,51 @@ async def database(_database_url, init_database) -> str:
         await drop_database(database_url)
 
 
+@pytest.fixture(scope="session")
+async def sqla_engine(database):
+    engine = create_async_engine(database)
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(scope="function")
+async def scoped_sqla_engine(database_url, init_database):
+    """
+    This fixture creates a new database just for the test function being run.
+    """
+    url_object = make_url(database_url)
+    scoped_sqla_url = url_object.set(database=url_object.database + "_function_scoped")
+    await create_database(scoped_sqla_url)
+
+    engine = create_async_engine(scoped_sqla_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(init_database)
+
+    try:
+        yield engine
+    finally:
+        await engine.dispose()
+        await drop_database(scoped_sqla_url)
+
+
+@pytest.fixture(scope="function")
+async def scoped_database(scoped_sqla_engine):
+    """
+    This fixture creates a new database just for the test function being run.
+    """
+    scoped_sqla_url = scoped_sqla_engine.url
+    return scoped_sqla_url.render_as_string(hide_password=False)
+
+
 @pytest.fixture()
-async def dbsession(_engine):
+async def db_session(sqla_engine):
     """
     Fixture that returns a SQLAlchemy session with a SAVEPOINT, and the rollback to it
     after the test completes.
     """
-    connection = await _engine.connect()
+    connection = await sqla_engine.connect()
     trans = await connection.begin()
 
     Session = sessionmaker(connection, expire_on_commit=False, class_=AsyncSession)
@@ -140,9 +105,61 @@ async def dbsession(_engine):
 
 
 @pytest.fixture()
+async def dbsession(db_session):
+    """
+    Alias for backward compatibility
+    """
+    yield db_session
+
+
+@pytest.fixture()
 async def transaction(_engine):
     conn = await _engine.begin()
     try:
         yield conn
     finally:
         await conn.rollback()
+
+
+POSTGRES_DEFAULT_DB = "postgres"
+
+
+async def create_database(url: str):
+    url_object = make_url(url)
+    database_name = url_object.database
+    dbms_url = url_object.set(database=POSTGRES_DEFAULT_DB)
+    engine = create_async_engine(dbms_url, isolation_level="AUTOCOMMIT")
+
+    async with engine.connect() as conn:
+        c = await conn.execute(
+            text(f"SELECT 1 FROM pg_database WHERE datname='{database_name}'")
+        )
+        database_exists = c.scalar() == 1
+
+    if database_exists:
+        await drop_database(url_object)
+
+    async with engine.connect() as conn:
+        await conn.execute(
+            text(f'CREATE DATABASE "{database_name}" ENCODING "utf8" TEMPLATE template1')
+        )
+    await engine.dispose()
+
+
+async def drop_database(url: str):
+    url_object = make_url(url)
+    dbms_url = url_object.set(database=POSTGRES_DEFAULT_DB)
+    engine = create_async_engine(dbms_url, isolation_level="AUTOCOMMIT")
+    async with engine.connect() as conn:
+        disc_users = """
+        SELECT pg_terminate_backend(pg_stat_activity.%(pid_column)s)
+        FROM pg_stat_activity
+        WHERE pg_stat_activity.datname = '%(database)s'
+          AND %(pid_column)s <> pg_backend_pid();
+        """ % {
+            "pid_column": "pid",
+            "database": url_object.database,
+        }
+        await conn.execute(text(disc_users))
+
+        await conn.execute(text(f'DROP DATABASE "{url_object.database}"'))


### PR DESCRIPTION
 - Add a `_` prefix to the fixture used to define the database URL:
   from `database_url` to `_database_url`
 - `_database_url` value is overridden by the `--database-url` CLI
   option, if given
 - `_engine` fixture renamed to `sqla_engine`
 - `database` fixture renamed to `scoped_database`. A new fixture
   named `database` gives access to the test session database
 - `function_scoped_database` fixture renamed to `scoped_sqla_engine`
 - `db_session` fixture renamed to `dbsession` (`dbsession` fixture
   was kept for backward compatibility)
